### PR TITLE
Update MongoSinkConnector to support Kafka 0.10+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ version := "1.0"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
-  "org.apache.kafka" % "connect-json" % "0.9.0.0" % "provided",
-  "org.apache.kafka" % "connect-api" % "0.9.0.0" % "provided",
+  "org.apache.kafka" % "connect-json" % "0.10.1.1" % "provided",
+  "org.apache.kafka" % "connect-api" % "0.10.1.1" % "provided",
   "org.mongodb" %% "casbah-core" % "3.1.1",
   "org.scalactic" %% "scalactic" % "3.0.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",

--- a/src/main/scala/com/startapp/data/MongoSinkConnector.scala
+++ b/src/main/scala/com/startapp/data/MongoSinkConnector.scala
@@ -2,6 +2,7 @@ package com.startapp.data
 
 import java.util
 
+import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
 import org.apache.kafka.connect.sink.SinkConnector
 
@@ -26,5 +27,7 @@ class MongoSinkConnector extends SinkConnector {
   }
 
   override def version(): String = getClass.getPackage.getImplementationVersion
+
+  override def config(): ConfigDef = MongoSinkConfig.configDef
 
 }


### PR DESCRIPTION
https://github.com/startappdev/kafka-connect-mongodb/issues/1

Updated build.sbt kafka dependencies to 0.10.1.1; 
Modified MongoSinkConnector to have config() method (needed for 0.10.0+ support)

